### PR TITLE
ACS-445 : Amp-a-lyser: Output tweaks for more consistency

### DIFF
--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/CustomCodeConflictPrinter.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/CustomCodeConflictPrinter.java
@@ -59,21 +59,18 @@ public class CustomCodeConflictPrinter implements ConflictPrinter
     public void printVerboseOutput(final String id, final Set<Conflict> conflictSet)
     {
         final String definingObject = conflictSet.iterator().next().getAmpResourceInConflict().getDefiningObject();
-        final Map<String, String> dependenciesPerAlfrescoVersion = conflictSet
+        final String invalidDependencies = conflictSet
             .stream()
             .map(c -> (CustomCodeConflict) c)
-            .collect(groupingBy(
-                Conflict::getAlfrescoVersion,
-                flatMapping(c -> c.getInvalidAlfrescoDependencies().stream().sorted(), joining(", "))
-            ));
+            .flatMap(c -> c.getInvalidAlfrescoDependencies().stream())
+            .distinct()
+            .sorted()
+            .collect(joining(", "));
 
         System.out.println(
             "Extension resource " + (id.equals(definingObject) ? id : id + "@" + definingObject)
-                + " has invalid (non PublicAPI) dependencies:");
-
-        dependenciesPerAlfrescoVersion
-            .forEach((k, v) -> System.out.println(k + ": " + v));
-
+                + " has invalid (non PublicAPI) dependencies: " + invalidDependencies);
+        System.out.println("Conflicting with: " + joinWarVersions(conflictSet));
         System.out.println();
     }
 

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/WarLibraryUsageConflictPrinter.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/WarLibraryUsageConflictPrinter.java
@@ -59,21 +59,18 @@ public class WarLibraryUsageConflictPrinter implements ConflictPrinter
     public void printVerboseOutput(final String id, final Set<Conflict> conflictSet)
     {
         final String definingObject = conflictSet.iterator().next().getAmpResourceInConflict().getDefiningObject();
-        final Map<String, String> dependenciesPerAlfrescoVersion = conflictSet
+        final String invalidDependencies = conflictSet
             .stream()
             .map(c -> (WarLibraryUsageConflict) c)
-            .collect(groupingBy(
-                Conflict::getAlfrescoVersion,
-                flatMapping(c -> c.getClassDependencies().stream().sorted(), joining(", "))
-            ));
+            .flatMap(c -> c.getClassDependencies().stream())
+            .distinct()
+            .sorted()
+            .collect(joining(", "));
 
         System.out.println(
             "Extension resource " + (id.equals(definingObject) ? id : id + "@" + definingObject)
-                + " has invalid (3rd party) dependencies:");
-
-        dependenciesPerAlfrescoVersion
-            .forEach((k, v) -> System.out.println(k + ": " + v));
-
+                + " has invalid (3rd party) dependencies: " + invalidDependencies);
+        System.out.println("Conflicting with: " + joinWarVersions(conflictSet));
         System.out.println();
     }
 


### PR DESCRIPTION
   - update output for custom code and 3rd party usage conflicts
```
Extension resource /org/alfresco/repo/action/ActionProgressTrackingServiceImpl.class@/lib/alfresco-renditionprogress-repo-1.4.2.jar has invalid (non PublicAPI) dependencies: /org/alfresco/repo/action/ActionImpl.class, /org/alfresco/repo/action/ActionTrackingServiceImpl.class, /org/alfresco/service/cmr/action/ExecutionDetails.class, /org/alfresco/service/cmr/action/ExecutionSummary.class
Conflicting with: 5.2.0 - 6.2.2

[.....]

Extension resource /com/amazonaws/http/apache/SdkProxyRoutePlanner.class@/lib/aws-java-sdk-core-1.11.599.jar has invalid (3rd party) dependencies: /org/apache/http/HttpException.class, /org/apache/http/HttpHost.class, /org/apache/http/HttpRequest.class, /org/apache/http/conn/SchemePortResolver.class, /org/apache/http/impl/conn/DefaultRoutePlanner.class, /org/apache/http/impl/conn/DefaultSchemePortResolver.class, /org/apache/http/protocol/HttpContext.class
Conflicting with: 5.2.0 - 6.2.2
```