### PR TITLE
ACS-456 : Amp-a-lyser: Beans instantiating extension specific classes should not be added as BeanRestrictedClass conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ Options:
 When running the analysing command, **Amp-a-lyser** writes the conflicts directly to the console, grouped by their type.
 
 The conflict types that can be detected by **Amp-a-lyser** are the following:
-* File overwrites
-* Bean overwrites
-* Classpath conflicts
-* Beans instantiating restricted classes
-* Usage of non @AlfrescoPublicAPI classes
-* Usage of 3rd party libraries
+* File overwrites (`FILE_OVERWRITE`)
+* Bean overwrites (`BEAN_OVERWRITE`)
+* Classpath conflicts (`CLASSPATH_CONFLICT`)
+* Beans instantiating restricted classes (`BEAN_RESTRICTED_CLASS`)
+* Usage of non @AlfrescoPublicAPI classes (`CUSTOM_CODE`)
+* Usage of 3rd party libraries (`WAR_LIBRARY_USAGE`)
 
 Example of output:
 ```text
@@ -151,6 +151,18 @@ Multiple resources in /lib/extension-lib.jar conflicting with /WEB-INF/lib/war-l
 
 (use option --verbose for version details)
 ```
+
+### Implementation details
+
+Alfresco extensions might hide conflicts of types `BEAN_RESTRICTED_CLASS`, `WAR_LIBRARY_USAGE` and `CUSTOM_CODE` if they contain Alfresco specific libraries.
+
+That's because the aforementioned types of conflicts exclude from processing all the classes in the extension's classpath.
+
+**Note:**
+
+Including in the processing a class present in both extension and war would partially solve the issue because:
+1. Two classes with the same canonical name could come from two different libraries, e.g. an extension specific library and an Alfresco one, or two different versions of the same Alfresco library. Thus checking the class name is not enough.
+2. Comparing their libraries would help only when the same library with the same version is used in both the extension and the war. In case of different versions of the same library, the class won't be recognized as Alfresco internal class.
 
 ## Build and release process
 

--- a/alfresco-ampalyser-analyser/src/test/java/org/alfresco/ampalyser/analyser/checker/BeanRestrictedClassesCheckerTest.java
+++ b/alfresco-ampalyser-analyser/src/test/java/org/alfresco/ampalyser/analyser/checker/BeanRestrictedClassesCheckerTest.java
@@ -25,6 +25,7 @@ import org.alfresco.ampalyser.analyser.service.ConfigService;
 import org.alfresco.ampalyser.analyser.service.ExtensionResourceInfoService;
 import org.alfresco.ampalyser.model.AlfrescoPublicApiResource;
 import org.alfresco.ampalyser.model.BeanResource;
+import org.alfresco.ampalyser.model.ClasspathElementResource;
 import org.alfresco.ampalyser.model.InventoryReport;
 import org.alfresco.ampalyser.model.Resource;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,12 @@ public class BeanRestrictedClassesCheckerTest
         BeanResource ampBR2 = new BeanResource("bean2", "amp_context.xml", "org.alfresco.C2");
         // This one should generate a conflict
         BeanResource ampBR3 = new BeanResource("bean3", "amp_context.xml", "org.alfresco.C3");
+        // This one should be allowed as it instantiates an extension specific class 
+        ClasspathElementResource ampCER4 = new ClasspathElementResource("/org/alfresco/C4",
+            "/WEB-INF/lib/an_extension.jar");
         doReturn(List.of(ampBR1, ampBR2, ampBR3)).when(configService).getExtensionResources(eq(BEAN));
+        doReturn(Map.of("/org/alfresco/C4.class", Set.of(ampCER4)))
+            .when(extensionResourceInfoService).retrieveClasspathElementsById();
 
         InventoryReport warReport = new InventoryReport();
         warReport.setAlfrescoVersion("6.66");


### PR DESCRIPTION
   - update BeanRestrictedClassesChecker to only process the classes that are not part of the extension
   - update existing test
   - add implementation notes in the README