### PR TITLE
ACS-80: AMP-a-lyser: Custom Java code using 3rd party libraries provided in the war file

### DIFF
--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/util/DependencyVisitor.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/util/DependencyVisitor.java
@@ -44,7 +44,7 @@ public class DependencyVisitor extends ClassVisitor
 
     public DependencyVisitor()
     {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM8);
     }
 
     //region ClassVisitor
@@ -128,7 +128,7 @@ public class DependencyVisitor extends ClassVisitor
     {
         public AnnotationDependencyVisitor()
         {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM8);
         }
 
         @Override
@@ -166,7 +166,7 @@ public class DependencyVisitor extends ClassVisitor
     {
         public FieldDependencyVisitor()
         {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM8);
         }
 
         @Override
@@ -190,7 +190,7 @@ public class DependencyVisitor extends ClassVisitor
     {
         public MethodDependencyVisitor()
         {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM8);
         }
 
         @Override
@@ -319,7 +319,7 @@ public class DependencyVisitor extends ClassVisitor
 
         public SignatureDependencyVisitor()
         {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM8);
         }
 
         @Override


### PR DESCRIPTION
- fix "This feature requires ASM7" error by updating to ASM8