### PR TITLE
ACS-507 : Amp-a-lyser : Improve `--verbose` output

### DIFF
--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/BeanOverwriteConflictPrinter.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/BeanOverwriteConflictPrinter.java
@@ -8,13 +8,18 @@
 
 package org.alfresco.ampalyser.analyser.printers;
 
+import static java.lang.String.valueOf;
 import static java.lang.System.lineSeparator;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.alfresco.ampalyser.analyser.printers.ConflictPrinter.joinExtensionDefiningObjs;
 import static org.alfresco.ampalyser.analyser.result.Conflict.Type.BEAN_OVERWRITE;
 import static org.alfresco.ampalyser.analyser.service.PrintingService.printTable;
 
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeMap;
 
 import org.alfresco.ampalyser.analyser.result.Conflict;
 import org.alfresco.ampalyser.analyser.store.WarInventoryReportStore;
@@ -30,6 +35,7 @@ public class BeanOverwriteConflictPrinter implements ConflictPrinter
             + "fundamental building block of the repository, and must not be "
             + "overwritten unless explicitly allowed." + lineSeparator()
             + "The following beans overwrite default functionality:";
+    private static final String EXTENSION_RESOURCE_ID = "Extension Bean Resource ID overriding WAR Bean";
 
     @Autowired
     private WarInventoryReportStore store;
@@ -55,20 +61,23 @@ public class BeanOverwriteConflictPrinter implements ConflictPrinter
     @Override
     public void printVerboseOutput(Set<Conflict> conflictSet)
     {
-        String[][] data = new String[conflictSet.size() + 1][3];
-        data[0][0] = "Extension Bean Resource ID";
-        data[0][1] = "Extension Defining Object";
-        data[0][2] = "WAR Version";
+        String[][] data =  conflictSet
+            .stream()
+            .collect(groupingBy(conflict -> conflict.getAmpResourceInConflict().getId(),
+                TreeMap::new,
+                toUnmodifiableSet()))
+            .entrySet().stream()
+            .map(entry -> List.of(
+                entry.getKey(),
+                entry.getValue().iterator().next().getAmpResourceInConflict().getDefiningObject(),
+                joinWarVersions(entry.getValue()),
+                valueOf(entry.getValue().size())))
+            .map(rowAsList -> rowAsList.toArray(new String[0]))
+            .toArray(String[][]::new);
 
-        int row = 1;
-        for (Conflict conflict : conflictSet)
-        {
-            data[row][0] = conflict.getAmpResourceInConflict().getId();
-            data[row][1] = conflict.getAmpResourceInConflict().getDefiningObject();
-            data[row][2] = conflict.getAlfrescoVersion();
-            row++;
-        }
-
+        data = ArrayUtils.insert(0, data, new String[][] {
+            new String[] { EXTENSION_RESOURCE_ID, EXTENSION_DEFINING_OBJECT, WAR_VERSION,
+                TOTAL } });
         printTable(data);
     }
 
@@ -78,15 +87,15 @@ public class BeanOverwriteConflictPrinter implements ConflictPrinter
         String[][] data = conflictSet.stream()
             .map(conflict -> List.of(
                 conflict.getAmpResourceInConflict().getId(),
-                ConflictPrinter.joinExtensionDefiningObjs(conflict.getAmpResourceInConflict().getId(), conflictSet),
+                joinExtensionDefiningObjs(conflict.getAmpResourceInConflict().getId(), conflictSet),
                 conflict.getWarResourceInConflict().getDefiningObject())
             )
             .distinct()
             .map(rowAsList -> rowAsList.toArray(new String[0]))
             .toArray(String[][]::new);
 
-        data = ArrayUtils.insert(0, data,
-            new String[][]{new String[]{"Extension Bean Resource ID", "Extension Defining Objects", "WAR Defining Object"}});
+        data = ArrayUtils.insert(0, data, new String[][] {
+            new String[] { EXTENSION_RESOURCE_ID, EXTENSION_DEFINING_OBJECT, WAR_DEFINING_OBJECTS } });
         printTable(data);
     }
 }

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/BeanRestrictedClassConflictPrinter.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/BeanRestrictedClassConflictPrinter.java
@@ -8,13 +8,17 @@
 
 package org.alfresco.ampalyser.analyser.printers;
 
+import static java.lang.String.valueOf;
 import static java.lang.System.lineSeparator;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.alfresco.ampalyser.analyser.result.Conflict.Type.BEAN_RESTRICTED_CLASS;
 import static org.alfresco.ampalyser.analyser.service.PrintingService.printTable;
 
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeMap;
 
 import org.alfresco.ampalyser.analyser.result.Conflict;
 import org.alfresco.ampalyser.analyser.store.WarInventoryReportStore;
@@ -31,6 +35,7 @@ public class BeanRestrictedClassConflictPrinter implements ConflictPrinter
         "Found beans that instantiate internal classes." + lineSeparator() + "The "
             + "following beans instantiate classes from Alfresco or 3rd party libraries which must "
             + "not be instantiated by custom beans:";
+    private static final String EXTENSION_RESOURCE_ID = "Extension Bean Resource ID instantiating Restricted Class";
 
     @Autowired
     private WarInventoryReportStore store;
@@ -56,22 +61,25 @@ public class BeanRestrictedClassConflictPrinter implements ConflictPrinter
     @Override
     public void printVerboseOutput(Set<Conflict> conflictSet)
     {
-        String[][] data = new String[conflictSet.size() + 1][4];
-        data[0][0] = "Extension Bean Resource ID";
-        data[0][1] = "Extension Defining Object";
-        data[0][2] = "Restricted Class";
-        data[0][3] = "WAR Version";
+        String[][] data =  conflictSet
+            .stream()
+            .collect(groupingBy(conflict -> conflict.getAmpResourceInConflict().getId(),
+                TreeMap::new,
+                toUnmodifiableSet()))
+            .entrySet().stream()
+            .map(entry -> List.of(
+                entry.getKey(),
+                entry.getValue().iterator().next().getAmpResourceInConflict().getDefiningObject(),
+                ((BeanResource)entry.getValue().iterator().next().getAmpResourceInConflict()).getBeanClass(),
+                joinWarVersions(entry.getValue()),
+                valueOf(entry.getValue().size())))
+            .map(rowAsList -> rowAsList.toArray(new String[0]))
+            .toArray(String[][]::new);
 
-        int row = 1;
-        for (Conflict conflict : conflictSet)
-        {
-            data[row][0] = conflict.getAmpResourceInConflict().getId();
-            data[row][1] = conflict.getAmpResourceInConflict().getDefiningObject();
-            data[row][2] = ((BeanResource)conflict.getAmpResourceInConflict()).getBeanClass();
-            data[row][3] = conflict.getAlfrescoVersion();
-            row++;
-        }
-
+        data = ArrayUtils.insert(0, data, new String[][] {
+            new String[] { EXTENSION_RESOURCE_ID, EXTENSION_DEFINING_OBJECT, RESTRICTED_CLASS,
+                WAR_VERSION, TOTAL } });
+        
         printTable(data);
     }
 
@@ -87,7 +95,7 @@ public class BeanRestrictedClassConflictPrinter implements ConflictPrinter
             .toArray(String[][]::new);
 
         data = ArrayUtils.insert(0, data,
-            new String[][]{new String[]{"Extension Bean Resource ID", "Restricted Class"}});
+            new String[][] { new String[] { EXTENSION_RESOURCE_ID, RESTRICTED_CLASS } });
         printTable(data);
     }
 }

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/ConflictPrinter.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/ConflictPrinter.java
@@ -34,7 +34,15 @@ import org.slf4j.LoggerFactory;
 public interface ConflictPrinter
 {
     Logger LOGGER = LoggerFactory.getLogger(ConflictPrinter.class);
-
+    
+    String EXTENSION_DEFINING_OBJECT = "Extension Defining Object";
+    String INVALID_3_RD_PARTY_DEPENDENCIES = "Invalid 3rd Party Dependencies";
+    String INVALID_DEPENDENCIES = "Invalid Dependencies";
+    String RESTRICTED_CLASS = "Restricted Class";
+    String WAR_DEFINING_OBJECTS = "WAR Defining Objects";
+    String WAR_VERSION = "WAR Versions";
+    String TOTAL = "Total conflicts";
+    
     default void print(final Map<String, Set<Conflict>> conflicts, final boolean verbose)
     {
         if (isEmpty(conflicts))


### PR DESCRIPTION
   - group versions per conflict
   - print a conflict only once, with its range of war versions
   - add new column for total conflicts of a particular extension resource