### PR TITLE
ACS-528 : Improve Amp-a-lyser output

### DIFF
--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/checker/AlfrescoInternalUsageChecker.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/checker/AlfrescoInternalUsageChecker.java
@@ -23,6 +23,7 @@ import org.alfresco.ampalyser.analyser.result.Conflict;
 import org.alfresco.ampalyser.analyser.service.ConfigService;
 import org.alfresco.ampalyser.analyser.service.ExtensionCodeAnalysisService;
 import org.alfresco.ampalyser.analyser.service.ExtensionResourceInfoService;
+import org.alfresco.ampalyser.model.AbstractResource;
 import org.alfresco.ampalyser.model.AlfrescoPublicApiResource;
 import org.alfresco.ampalyser.model.ClasspathElementResource;
 import org.alfresco.ampalyser.model.InventoryReport;
@@ -63,7 +64,7 @@ public class AlfrescoInternalUsageChecker implements Checker
             .stream()
             .map(r -> (AlfrescoPublicApiResource) r)
             .collect(toUnmodifiableMap(
-                r -> "/" + r.getId().replace(".", "/") + ".class",
+                AbstractResource::getId,
                 AlfrescoPublicApiResource::isDeprecated
             ));
 
@@ -82,8 +83,9 @@ public class AlfrescoInternalUsageChecker implements Checker
                     .stream()
                     .filter(d -> d.startsWith("/org/alfresco/")) // It is an Alfresco class
                     .filter(d -> !extensionClassesById.containsKey(d)) // Not defined inside the AMP
-                    .filter(d -> (!publicApis.containsKey(d) || publicApis.get(d))) // Not PublicAPI or Deprecated_PublicAPI
                     .filter(d -> !isInAllowedList(d, allowedInternalClasses)) // Not Allowed Internal Class
+                    .map(d -> d.substring(1).replaceAll("/", ".").replace(".class", ""))
+                    .filter(d -> (!publicApis.containsKey(d) || publicApis.get(d))) // Not PublicAPI or Deprecated_PublicAPI
                     .collect(toUnmodifiableSet())
             ))
             .filter(e -> !e.getValue().isEmpty()) // strip entries without invalid dependencies

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/checker/WarLibraryUsageChecker.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/checker/WarLibraryUsageChecker.java
@@ -9,6 +9,7 @@ package org.alfresco.ampalyser.analyser.checker;
 
 import static java.util.Collections.emptySet;
 import static java.util.Map.entry;
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.alfresco.ampalyser.analyser.checker.Checker.isInAllowedList;
 import static org.alfresco.ampalyser.model.Resource.Type.CLASSPATH_ELEMENT;
@@ -50,16 +51,16 @@ public class WarLibraryUsageChecker implements Checker
 
         // Iterate through the WAR classpath elements and keep the ones that could be dependencies of the extension.
         // We keep this intermediate data structure (Set), so that we don't hash the entire War inventory
-        final Set<String> classesInWar = warInventory
+        final Map<String, Set<Resource>> resourcesInWar = warInventory
             .getResources().getOrDefault(CLASSPATH_ELEMENT, emptySet())
             .stream()
-            .map(Resource::getId)
-            .filter(s -> s.endsWith(".class"))
-            .filter(s -> !s.startsWith("/org/alfresco/")) // strip Alfresco Classes
-            .filter(s -> !s.startsWith("/javax/")) // strip JavaX Classes
-            .filter(allExtensionDependencies::contains) // keep if the WAR entry could be a dependency of the extension
-            .collect(toUnmodifiableSet());
-
+            .filter(s -> s.getId().endsWith(".class"))
+            .filter(s -> !s.getId().startsWith("/org/alfresco/")) // strip Alfresco Classes
+            .filter(s -> !s.getId().startsWith("/javax/")) // strip JavaX Classes
+            .filter(s -> allExtensionDependencies.contains(s.getId())) // keep if the WAR entry could be a dependency of the extension
+            .collect(groupingBy(Resource::getId,toUnmodifiableSet()));
+        final Set<String> classesInWar = resourcesInWar.keySet();
+        
         final Map<String, Set<ClasspathElementResource>> extensionClassesById =
             extensionResourceInfoService.retrieveClasspathElementsById();
 
@@ -84,7 +85,10 @@ public class WarLibraryUsageChecker implements Checker
                 .stream()
                 .map(r -> new WarLibraryUsageConflict(
                     r,
-                    e.getValue(),
+                    e.getValue()
+                        .stream()
+                        .flatMap(s->resourcesInWar.get(s).stream())
+                        .collect(toUnmodifiableSet()),
                     alfrescoVersion
                 )));
 

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/BeanOverwriteConflictPrinter.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/BeanOverwriteConflictPrinter.java
@@ -8,9 +8,11 @@
 
 package org.alfresco.ampalyser.analyser.printers;
 
+import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static java.lang.System.lineSeparator;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.alfresco.ampalyser.analyser.result.Conflict.Type.BEAN_OVERWRITE;
 import static org.alfresco.ampalyser.analyser.service.PrintingService.printTable;
@@ -29,11 +31,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class BeanOverwriteConflictPrinter implements ConflictPrinter
 {
-    private static final String HEADER =
-        "Found bean overwrites. Spring beans defined by Alfresco are a "
-            + "fundamental building block of the repository, and must not be "
-            + "overwritten unless explicitly allowed." + lineSeparator()
-            + "The following beans overwrite default functionality:";
+    private static final String HEADER = "The following Spring beans defined in the extension module are in conflict with beans defined in the ACS repository:";
+    private static final String DESCRIPTION =
+        "Spring beans are the basic building blocks of the ACS repository. Replacing these will alter the behaviour of the system and can lead to unexpected behaviour."
+            + lineSeparator()
+            + "Since all these beans are subject to change between Alfresco versions and even in service packs, these modifications are typically bound to a specific Alfresco version."
+            + lineSeparator()
+            + "You should avoid redefining default beans of the ACS repository in your extensions to reduce the cost of upgrades."
+            + lineSeparator()
+            + "It is possible that these conflicts only exist in specific ACS versions. Run this tool with the -verbose option to get a complete list of versions where each of these file has conflicts.";
     private static final String EXTENSION_RESOURCE_ID = "Extension Bean ID overriding WAR Bean";
 
     @Autowired
@@ -51,6 +57,18 @@ public class BeanOverwriteConflictPrinter implements ConflictPrinter
         return HEADER;
     }
 
+    @Override
+    public String getDescription()
+    {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public String getSection()
+    {
+        return "Bean naming conflicts";
+    }
+    
     @Override
     public Conflict.Type getConflictType()
     {
@@ -83,20 +101,12 @@ public class BeanOverwriteConflictPrinter implements ConflictPrinter
     @Override
     public void print(Set<Conflict> conflictSet)
     {
-        String[][] data =  conflictSet
-            .stream()
-            .collect(groupingBy(conflict -> conflict.getAmpResourceInConflict().getId(),
-                TreeMap::new,
-                toUnmodifiableSet()))
-            .entrySet().stream()
-            .map(entry -> List.of(
-                entry.getKey(),
-                valueOf(entry.getValue().size())))
-            .map(rowAsList -> rowAsList.toArray(new String[0]))
-            .toArray(String[][]::new);
-
-        data = ArrayUtils.insert(0, data, new String[][] {
-            new String[] { EXTENSION_RESOURCE_ID, TOTAL } });
-        printTable(data);
+        System.out.println(
+            conflictSet
+                .stream()
+                .map(conflict -> format("\t%s",conflict.getAmpResourceInConflict().getId()))
+                .distinct()
+                .sorted()
+                .collect(joining("\n")));
     }
 }

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/ConflictPrinter.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/ConflictPrinter.java
@@ -14,6 +14,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.repeat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,8 +36,8 @@ public interface ConflictPrinter
     Logger LOGGER = LoggerFactory.getLogger(ConflictPrinter.class);
     
     String EXTENSION_DEFINING_OBJECT = "Extension Defining Object";
-    String INVALID_3_RD_PARTY_DEPENDENCIES = "Invalid 3rd Party Dependencies";
-    String INVALID_DEPENDENCIES = "Invalid Dependencies";
+    String THIRD_PARTY_DEPENDENCIES = "3rd Party Libraries";
+    String INTERNAL_REPOSITORY_CLASSES = "Internal Repository Classes";
     String RESTRICTED_CLASS = "Restricted Class";
     String WAR_DEFINING_OBJECTS = "WAR Defining Objects";
     String WAR_VERSION = "WAR Versions";
@@ -55,22 +56,31 @@ public interface ConflictPrinter
             .flatMap(Set::stream)
             .collect(toSet());
 
-        System.out.println(getConflictType() + " CONFLICTS. " + getHeader());
-
         try
         {
             if (verbose)
             {
+                System.out.println(getSection());
+                System.out.println(repeat("-", getSection().length()));
+                System.out.println(getDescription());
+                System.out.println(getHeader());
+                
                 printVerboseOutput(allConflicts);
             }
             else
             {
+                System.out.println(getSection());
+                System.out.println(repeat("-", getSection().length()));
+                System.out.println(getHeader());
+                
                 print(allConflicts);
+                
+                System.out.println(getDescription());
             }
         }
         catch (Exception e)
         {
-            LOGGER.warn("Failed to print " + getConflictType() + " conflicts!", e);
+            LOGGER.warn("Failed to print " + getSection(), e);
         }
 
         System.out.println();
@@ -79,6 +89,10 @@ public interface ConflictPrinter
     SortedSet<String> retrieveAllKnownVersions();
     
     String getHeader();
+    
+    String getDescription();
+    
+    String getSection();
 
     Conflict.Type getConflictType();
 

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/FileOverwriteConflictPrinter.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/FileOverwriteConflictPrinter.java
@@ -8,9 +8,11 @@
 
 package org.alfresco.ampalyser.analyser.printers;
 
+import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static java.lang.System.lineSeparator;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.alfresco.ampalyser.analyser.result.Conflict.Type.FILE_OVERWRITE;
 import static org.alfresco.ampalyser.analyser.service.PrintingService.printTable;
@@ -29,11 +31,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class FileOverwriteConflictPrinter implements ConflictPrinter
 {
-    private static final String HEADER =
-        "Found resource conflicts." + lineSeparator() + "The following resources will "
-            + "conflict with resources used in various Alfresco versions, so you won't be able "
-            + "to install this extension on these versions. Try using the "
-            + "--target option to limit this scan to specific Alfresco versions.";
+    private static final String HEADER = "The following files in the extension module conflict with resources in the ACS repository:";
+    private static final String DESCRIPTION =
+        "The module management tool will reject modules with file conflicts, making it impossible to install this module."
+            + lineSeparator()
+            + "It is possible that these conflicts only exist in specific ACS versions. Run this tool with the -verbose option to get a complete list of versions where each of these file has conflicts.";
     private static final String EXTENSION_RESOURCE_ID = "Extension Resource overwriting WAR resource";
 
     @Autowired
@@ -49,6 +51,18 @@ public class FileOverwriteConflictPrinter implements ConflictPrinter
     public String getHeader()
     {
         return HEADER;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public String getSection()
+    {
+        return "File conflicts";
     }
 
     @Override
@@ -81,20 +95,12 @@ public class FileOverwriteConflictPrinter implements ConflictPrinter
     @Override
     public void print(Set<Conflict> conflictSet)
     {
-        String[][] data =  conflictSet
-            .stream()
-            .collect(groupingBy(conflict -> conflict.getAmpResourceInConflict().getId(),
-                TreeMap::new,
-                toUnmodifiableSet()))
-            .entrySet().stream()
-            .map(entry -> List.of(
-                entry.getKey(),
-                valueOf(entry.getValue().size())))
-            .map(rowAsList -> rowAsList.toArray(new String[0]))
-            .toArray(String[][]::new);
-
-        data = ArrayUtils.insert(0, data,
-            new String[][] { new String[] { EXTENSION_RESOURCE_ID, TOTAL } });
-        printTable(data);
+        System.out.println(
+            conflictSet
+                .stream()
+                .map(conflict -> format("\t%s",conflict.getAmpResourceInConflict().getId()))
+                .distinct()
+                .sorted()
+                .collect(joining("\n")));
     }
 }

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/WarLibraryUsageConflictPrinter.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/printers/WarLibraryUsageConflictPrinter.java
@@ -8,10 +8,12 @@
 
 package org.alfresco.ampalyser.analyser.printers;
 
+import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.lang.String.valueOf;
 import static java.lang.System.lineSeparator;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.alfresco.ampalyser.analyser.result.Conflict.Type.WAR_LIBRARY_USAGE;
 import static org.alfresco.ampalyser.analyser.service.PrintingService.printTable;
@@ -24,6 +26,7 @@ import java.util.TreeMap;
 import org.alfresco.ampalyser.analyser.result.Conflict;
 import org.alfresco.ampalyser.analyser.result.WarLibraryUsageConflict;
 import org.alfresco.ampalyser.analyser.store.WarInventoryReportStore;
+import org.alfresco.ampalyser.model.Resource;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -31,12 +34,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class WarLibraryUsageConflictPrinter implements ConflictPrinter
 {
-    private static final String HEADER =
-        "Found 3rd party library usage. Although this isn't an immediate problem, all 3rd party "
-            + "libraries that are delivered with the repository are considered as our internal "
-            + "implementation detail. These libraries will change or may be removed in future "
-            + "service packs without notice." + lineSeparator()
-            + "The following classes use 3rd party libraries:";
+    private static final String HEADER = "The code provided by the extension module is using these 3rd party libraries brought by the ACS repository:";
+    private static final String DESCRIPTION =
+        "These 3rd party libraries are managed by the ACS repository and are subject to constant change, even in service packs and hotfixes."
+            + lineSeparator()
+            + "Each of these libraries has its own backward compatibility strategy, which will make it really hard for this extension to keep up with these changes.";
     private static final String EXTENSION_RESOURCE_ID = "Extension Resource using 3rd Party library code";
 
     @Autowired
@@ -55,6 +57,18 @@ public class WarLibraryUsageConflictPrinter implements ConflictPrinter
     }
 
     @Override
+    public String getDescription()
+    {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public String getSection()
+    {
+        return "Custom code using 3rd party libraries managed by the ACS repository";
+    }
+
+    @Override
     public Conflict.Type getConflictType()
     {
         return WAR_LIBRARY_USAGE;
@@ -70,10 +84,12 @@ public class WarLibraryUsageConflictPrinter implements ConflictPrinter
                 toUnmodifiableSet()))
             .entrySet().stream()
             .map(entry -> List.of(
-                entry.getKey(),
+                entry.getKey().substring(1).replaceAll("/", ".").replace(".class", ""),
                 entry.getValue().iterator().next().getAmpResourceInConflict().getDefiningObject(),
-                join("\n\n",((WarLibraryUsageConflict) entry.getValue().iterator().next())
-                    .getClassDependencies()),// Empty line between dependencies for output readability
+                join("\n\n",entry.getValue().stream()
+                    .flatMap(c -> ((WarLibraryUsageConflict) c).getDependencies().stream())
+                    .map(Resource::getDefiningObject)
+                    .collect(toUnmodifiableSet())),// Empty line between dependencies for output readability
                 joinWarVersions(entry.getValue()),
                 valueOf(entry.getValue().size())))
             .map(rowAsList -> rowAsList.toArray(new String[0]))
@@ -81,27 +97,22 @@ public class WarLibraryUsageConflictPrinter implements ConflictPrinter
 
         data = ArrayUtils.insert(0, data, new String[][] {
             new String[] { EXTENSION_RESOURCE_ID, EXTENSION_DEFINING_OBJECT,
-                INVALID_3_RD_PARTY_DEPENDENCIES, WAR_VERSION, TOTAL } });
+                THIRD_PARTY_DEPENDENCIES, WAR_VERSION, TOTAL } });
          printTable(data);
     }
 
     @Override
     public void print(final Set<Conflict> conflictSet)
     {
-        String[][] data =  conflictSet
-            .stream()
-            .collect(groupingBy(conflict -> conflict.getAmpResourceInConflict().getId(),
-                TreeMap::new,
-                toUnmodifiableSet()))
-            .entrySet().stream()
-            .map(entry -> List.of(
-                entry.getKey(),
-                valueOf(entry.getValue().size())))
-            .map(rowAsList -> rowAsList.toArray(new String[0]))
-            .toArray(String[][]::new);
-
-        data = ArrayUtils.insert(0, data, new String[][] {
-            new String[] { EXTENSION_RESOURCE_ID, TOTAL } });
-        printTable(data);
+        System.out.println(
+            conflictSet
+                .stream()
+                .flatMap(conflict -> ((WarLibraryUsageConflict) conflict).getDependencies()
+                    .stream()
+                    .map(Resource::getDefiningObject))
+                .distinct()
+                .sorted()
+                .map(s -> format("\t%s", s))
+                .collect(joining("\n")));
     }
 }

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/result/WarLibraryUsageConflict.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/result/WarLibraryUsageConflict.java
@@ -13,30 +13,31 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.alfresco.ampalyser.model.ClasspathElementResource;
+import org.alfresco.ampalyser.model.Resource;
 
 public class WarLibraryUsageConflict extends AbstractConflict
 {
-    private Set<String> classDependencies;
+    private Set<Resource> dependencies;
 
     public WarLibraryUsageConflict()
     {
     }
 
-    public WarLibraryUsageConflict(ClasspathElementResource ampResourceInConflict, Set<String> classDependencies,
+    public WarLibraryUsageConflict(ClasspathElementResource ampResourceInConflict, Set<Resource> dependencies,
         String alfrescoVersion)
     {
         super(WAR_LIBRARY_USAGE, ampResourceInConflict, null, alfrescoVersion);
-        this.classDependencies = classDependencies;
+        this.dependencies = dependencies;
     }
 
-    public Set<String> getClassDependencies()
+    public Set<Resource> getDependencies()
     {
-        return classDependencies;
+        return dependencies;
     }
 
-    public void setClassDependencies(Set<String> classDependencies)
+    public void setDependencies(Set<Resource> dependencies)
     {
-        this.classDependencies = classDependencies;
+        this.dependencies = dependencies;
     }
 
     @Override
@@ -46,20 +47,20 @@ public class WarLibraryUsageConflict extends AbstractConflict
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         WarLibraryUsageConflict that = (WarLibraryUsageConflict) o;
-        return Objects.equals(classDependencies, that.classDependencies);
+        return Objects.equals(dependencies, that.dependencies);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(super.hashCode(), classDependencies);
+        return Objects.hash(super.hashCode(), dependencies);
     }
 
     @Override
     public String toString()
     {
         return "WarLibraryUsageConflict{" +
-               "classDependencies=" + classDependencies +
+               "classDependencies=" + dependencies +
                "} " + super.toString();
     }
 }

--- a/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/service/PrintingService.java
+++ b/alfresco-ampalyser-analyser/src/main/java/org/alfresco/ampalyser/analyser/service/PrintingService.java
@@ -40,6 +40,5 @@ public class PrintingService
         }
 
         System.out.println(tableBuilder.build().render(180));
-        System.out.println();
     }
 }

--- a/alfresco-ampalyser-analyser/src/test/java/org/alfresco/ampalyser/analyser/checker/AlfrescoInternalUsageCheckerTest.java
+++ b/alfresco-ampalyser-analyser/src/test/java/org/alfresco/ampalyser/analyser/checker/AlfrescoInternalUsageCheckerTest.java
@@ -14,8 +14,8 @@ import static org.mockito.Mockito.spy;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.ampalyser.analyser.result.Conflict;
 import org.alfresco.ampalyser.analyser.result.AlfrescoInternalUsageConflict;
+import org.alfresco.ampalyser.analyser.result.Conflict;
 import org.alfresco.ampalyser.analyser.service.ConfigService;
 import org.alfresco.ampalyser.analyser.service.ExtensionCodeAnalysisService;
 import org.alfresco.ampalyser.analyser.service.ExtensionResourceInfoService;
@@ -35,6 +35,7 @@ class AlfrescoInternalUsageCheckerTest
 {
     private static final String OAA = "/org/alfresco/amp/";
     private static final String OAW = "/org/alfresco/war/";
+    private static final String OAW_PACKAGE = "org.alfresco.war.";
 
     @Mock
     private ConfigService configService;
@@ -113,15 +114,15 @@ class AlfrescoInternalUsageCheckerTest
 
         final Set<Conflict> expected = Set.of(
             conflict(ampRes("deps_to_core_alf_classes_which_is_baaad.class"),
-                Set.of(OAW + "c1.class", OAW + "c2.class")),
+                Set.of(OAW_PACKAGE + "c1", OAW_PACKAGE + "c2")),
 
             conflict(ampRes("deps_to_deprecated_alfresco_public_api_classes.class"),
-                Set.of(OAW + "c_APA_3deprecated.class", OAW + "c_APA_4deprecated.class")),
+                Set.of(OAW_PACKAGE + "c_APA_3deprecated", OAW_PACKAGE + "c_APA_4deprecated")),
 
             conflict(ampRes("deps_to_everything.class"),
                 Set.of(
-                    OAW + "c1.class", OAW + "c2.class",
-                    OAW + "c_APA_3deprecated.class", OAW + "c_APA_4deprecated.class"
+                    OAW_PACKAGE + "c1", OAW_PACKAGE + "c2",
+                    OAW_PACKAGE + "c_APA_3deprecated", OAW_PACKAGE + "c_APA_4deprecated"
                 )));
         assertEquals(expected.size(), result.size());
         expected.forEach(c -> assertTrue(result.contains(c)));

--- a/alfresco-ampalyser-analyser/src/test/java/org/alfresco/ampalyser/analyser/checker/WarLibraryUsageCheckerTest.java
+++ b/alfresco-ampalyser-analyser/src/test/java/org/alfresco/ampalyser/analyser/checker/WarLibraryUsageCheckerTest.java
@@ -20,6 +20,7 @@ import org.alfresco.ampalyser.analyser.service.ExtensionCodeAnalysisService;
 import org.alfresco.ampalyser.analyser.service.ExtensionResourceInfoService;
 import org.alfresco.ampalyser.model.ClasspathElementResource;
 import org.alfresco.ampalyser.model.InventoryReport;
+import org.alfresco.ampalyser.model.Resource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -160,15 +161,17 @@ class WarLibraryUsageCheckerTest
         final Set<Conflict> result = checker.process(warInventory, "6.0.0").collect(toSet());
 
         final Set<Conflict> expected = Set.of(
-            conflict(res("/com/example/test/C51.class", "color"), Set.of("/com/example/test/W10.class")),
-            conflict(res("/com/example/test/C52.class", "color"), Set.of("/com/example/test/W17.class")),
-            conflict(res("/com/example/test/C53.class", "color"), Set.of("/com/example/test/W13.class")),
-            conflict(res("/com/example/test/C54.class", "color"), Set.of("/com/example/test/W11.class", "/com/example/test/W15.class")),
-            conflict(res("/com/example/test/C55.class", "color"), Set.of("/com/example/test/W19.class")),
-            conflict(res("/com/example/test/C56.class", "color"), Set.of("/com/example/test/W20.class")),
-            conflict(res("/com/example/test/A2.class", "white"), Set.of("/com/example/test/W21.class")),
-            conflict(res("/com/example/test/A2.class", "black"), Set.of("/com/example/test/W21.class")),
-            conflict(res("/com/example/test/C61.class", "color"), Set.of("/com/example/test/W22.class"))
+            conflict(res("/com/example/test/C51.class", "color"), Set.of(new ClasspathElementResource(
+                "/com/example/test/W10.class", "test.jar"))),
+            conflict(res("/com/example/test/C52.class", "color"), Set.of(new ClasspathElementResource("/com/example/test/W17.class", "test.jar"))),
+            conflict(res("/com/example/test/C53.class", "color"), Set.of(new ClasspathElementResource("/com/example/test/W13.class", "test.jar"))),
+            conflict(res("/com/example/test/C54.class", "color"), Set.of(new ClasspathElementResource("/com/example/test/W11.class", "test.jar"), 
+                new ClasspathElementResource("/com/example/test/W15.class", "test.jar"))),
+            conflict(res("/com/example/test/C55.class", "color"), Set.of(new ClasspathElementResource("/com/example/test/W19.class", "test.jar"))),
+            conflict(res("/com/example/test/C56.class", "color"), Set.of(new ClasspathElementResource("/com/example/test/W20.class", "test.jar"))),
+            conflict(res("/com/example/test/A2.class", "white"), Set.of(new ClasspathElementResource("/com/example/test/W21.class", "test.jar"))),
+            conflict(res("/com/example/test/A2.class", "black"), Set.of(new ClasspathElementResource("/com/example/test/W21.class", "test.jar"))),
+            conflict(res("/com/example/test/C61.class", "color"), Set.of(new ClasspathElementResource("/com/example/test/W22.class", "test.jar")))
         );
         assertEquals(expected.size(), result.size());
         expected.forEach(c -> assertTrue(expected.contains(c)));
@@ -213,9 +216,9 @@ class WarLibraryUsageCheckerTest
         final Set<Conflict> result = checker.process(warInventory, "6.0.0").collect(toSet());
 
         final Set<Conflict> expected = Set.of(
-            conflict(res("/com/example/amp/A3.class", "color"), Set.of("/com/example/abc/X2.class")),
-            conflict(res("/com/example/amp/A2.class", "color"), Set.of("/com/example/abc/X2.class")),
-            conflict(res("/com/example/amp/A1.class", "color"), Set.of("/com/example/abc/X1.class"))
+            conflict(res("/com/example/amp/A3.class", "color"), Set.of(new ClasspathElementResource("/com/example/abc/X2.class", "test.jar"))),
+            conflict(res("/com/example/amp/A2.class", "color"), Set.of(new ClasspathElementResource("/com/example/abc/X2.class", "test.jar"))),
+            conflict(res("/com/example/amp/A1.class", "color"), Set.of(new ClasspathElementResource("/com/example/abc/X1.class", "test.jar")))
         );
         assertEquals(expected.size(), result.size());
         expected.forEach(c -> assertTrue(expected.contains(c)));
@@ -226,7 +229,7 @@ class WarLibraryUsageCheckerTest
         return new ClasspathElementResource(id, definingObject);
     }
 
-    private static WarLibraryUsageConflict conflict(ClasspathElementResource resource, Set<String> classes)
+    private static WarLibraryUsageConflict conflict(ClasspathElementResource resource, Set<Resource> classes)
     {
         return new WarLibraryUsageConflict(resource, classes, "6.0.0");
     }


### PR DESCRIPTION
   - remove table format from non-verbose output
   - update headers and descriptions on each conflict section
   - output formatting
   - print more relevant information in non-verbose mode