### PR TITLE
Fix the Release secrets as per the Github Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
+  RELEASE_AWS_ACCESS_KEY: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
+  RELEASE_AWS_SECRET_KEY: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
 
 jobs:
   tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ on:
 
 env:
   SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-  RELEASE_AWS_ACCESS_KEY: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
-  RELEASE_AWS_SECRET_KEY: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
 
 jobs:
   tests:
@@ -84,6 +82,9 @@ jobs:
     name: "Copy-to-S3-Release-Bucket"
     runs-on: ubuntu-latest
     needs: release
+    env:
+      RELEASE_AWS_ACCESS_KEY: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
+      RELEASE_AWS_SECRET_KEY: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
     if: >
       contains(github.event.head_commit.message, '[publish]') && 
       github.ref_name == 'master'


### PR DESCRIPTION
The copy_to_release_bucket.sh script which is used in publish job uses RELEASE_AWS_ACCESS_KEY and RELEASE_AWS_SECRET_KEY variables which were configured in Travis. With migration to Github Action, we have to use secrets - AWS_S3_RELEASE_ACCESS_KEY_ID and AWS_S3_RELEASE_SECRET_ACCESS_KEY. Hence modified the code to use organisation secrets and assign the value to RELEASE_AWS_ACCESS_KEY and RELEASE_AWS_SECRET_KEY.