### PR TITLE
ACS-8676 Deal with upcoming GitHub Actions deprecations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 17
@@ -61,7 +61,7 @@ jobs:
           cp -v _ci/settings.xml ${HOME}/.m2/ || cp -v .travis.settings.xml ${HOME}/.m2/settings.xml
 
       - name: Cache the Maven packages to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -81,7 +81,7 @@ jobs:
     if: ${{ ( startsWith(github.ref_name, 'support/') || github.ref_name == 'master' ) &&
         contains(github.event.head_commit.message, '[release]') || inputs.commitMessage == '[release]' }}
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -96,10 +96,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_S3_STAGING_SECRET_KEY }}
           aws-region: eu-west-1
 
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v3.3.3
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
 
       - name: Get branch name
-        uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name@v3.3.3
+        uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name@v7.0.0
 
       - name: Setup maven
         shell: bash


### PR DESCRIPTION
Migrate from `Node16` to `Node20`.
Additionally: upgrading the version to the latest for other actions from the `alfresco-build-tools`.