### PR TITLE
ACS-12158 - Alfresco Extension Inspector 2.7.0 A.1 please [release]

### DIFF
--- a/extension-inspector-analyser/pom.xml
+++ b/extension-inspector-analyser/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.alfresco.extension-inspector</groupId>
         <artifactId>alfresco-extension-inspector-parent</artifactId>
-        <version>2.6.1-SNAPSHOT</version>
+        <version>2.7.0-A.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>alfresco-extension-inspector-analyser</artifactId>
@@ -17,12 +17,12 @@
         <dependency>
             <groupId>org.alfresco.extension-inspector</groupId>
             <artifactId>alfresco-extension-inspector-commons</artifactId>
-            <version>2.6.1-SNAPSHOT</version>
+            <version>2.7.0-A.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.alfresco.extension-inspector</groupId>
             <artifactId>alfresco-extension-inspector-inventory</artifactId>
-            <version>2.6.1-SNAPSHOT</version>
+            <version>2.7.0-A.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/extension-inspector-commons/pom.xml
+++ b/extension-inspector-commons/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.alfresco.extension-inspector</groupId>
         <artifactId>alfresco-extension-inspector-parent</artifactId>
-        <version>2.6.1-SNAPSHOT</version>
+        <version>2.7.0-A.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>alfresco-extension-inspector-commons</artifactId>

--- a/extension-inspector-inventory/pom.xml
+++ b/extension-inspector-inventory/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.alfresco.extension-inspector</groupId>
         <artifactId>alfresco-extension-inspector-parent</artifactId>
-        <version>2.6.1-SNAPSHOT</version>
+        <version>2.7.0-A.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>alfresco-extension-inspector-inventory</artifactId>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.alfresco.extension-inspector</groupId>
             <artifactId>alfresco-extension-inspector-commons</artifactId>
-            <version>2.6.1-SNAPSHOT</version>
+            <version>2.7.0-A.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/extension-inspector-packaging/pom.xml
+++ b/extension-inspector-packaging/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.alfresco.extension-inspector</groupId>
         <artifactId>alfresco-extension-inspector-parent</artifactId>
-        <version>2.6.1-SNAPSHOT</version>
+        <version>2.7.0-A.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>alfresco-extension-inspector</artifactId>
@@ -17,12 +17,12 @@
         <dependency>
             <groupId>org.alfresco.extension-inspector</groupId>
             <artifactId>alfresco-extension-inspector-inventory</artifactId>
-            <version>2.6.1-SNAPSHOT</version>
+            <version>2.7.0-A.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.alfresco.extension-inspector</groupId>
             <artifactId>alfresco-extension-inspector-analyser</artifactId>
-            <version>2.6.1-SNAPSHOT</version>
+            <version>2.7.0-A.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/extension-inspector-test/pom.xml
+++ b/extension-inspector-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.alfresco.extension-inspector</groupId>
         <artifactId>alfresco-extension-inspector-parent</artifactId>
-        <version>2.6.1-SNAPSHOT</version>
+        <version>2.7.0-A.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>alfresco-extension-inspector-test</artifactId>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.alfresco.extension-inspector</groupId>
             <artifactId>alfresco-extension-inspector-commons</artifactId>
-            <version>2.6.1-SNAPSHOT</version>
+            <version>2.7.0-A.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.alfresco.extension-inspector</groupId>
     <artifactId>alfresco-extension-inspector-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.7.0-A.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>alfresco-extension-inspector-parent</name>


### PR DESCRIPTION
https://hyland.atlassian.net/browse/ACS-12158
According to the above jira , the alpha version of Alfresco Extension Inspector 2.7.0 is about to release.